### PR TITLE
Fix modifier error

### DIFF
--- a/alps/src/pegasus/pegasthread.cc
+++ b/alps/src/pegasus/pegasthread.cc
@@ -18,6 +18,6 @@
 
 namespace alps {
 
-__thread PegasThread pegas_thread;
+thread_local PegasThread pegas_thread;
 
 } // namespace alps


### PR DESCRIPTION
Fix `__thread PegasThread pegas_thread` to `thread_local PegasThread pegas_thread` because pegasthread.hh defines it as `thread_local`.