### PR TITLE
Fix syntax error

### DIFF
--- a/firesteel/pom.xml
+++ b/firesteel/pom.xml
@@ -23,14 +23,14 @@
 	<groupId>com.hp.hpl</groupId>
 	<artifactId>firesteel</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>2.0.0</version>
 	<name>HP Labs Project Fire Steel</name>
 
 	<properties>
 	        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
                 <scala.version>2.11.8</scala.version>
                 <scala.binary.version>2.11</scala.binary.version>
-                <spark.version>2.0.0-SNAPSHOT</spark.version>
+                <spark.version>2.0.0</spark.version>
                 <slf4j.version>1.7.5</slf4j.version>
                 <log4j.version>1.2.17</log4j.version>
                 <kryo.version>3.0.3</kryo.version>
@@ -65,7 +65,7 @@
         <dependency>  
             <groupId>org.apache.spark</groupId>  
             <artifactId>spark-core_${scala.binary.version}</artifactId>  
-            <version>2.0.0-SNAPSHOT</version>  
+            <version>2.0.0</version>  
         </dependency> 
 
         <!-- this is the dependent networking library installed in the local repository-->

--- a/firesteel/src/main/cpp/offheapstore/OffHeapStoreManager.cc
+++ b/firesteel/src/main/cpp/offheapstore/OffHeapStoreManager.cc
@@ -16,6 +16,7 @@
  */
 
 #include <glog/logging.h>
+#include <immintrin.h>
 #include "OffHeapStoreManager.h"
 #include "OffHeapStoreConstants.h"
 #include "ShmAddress.h"

--- a/firesteel/src/main/scala/org/apache/spark/shuffle/shm/ShmShuffleManager.scala
+++ b/firesteel/src/main/scala/org/apache/spark/shuffle/shm/ShmShuffleManager.scala
@@ -70,7 +70,7 @@ private[spark] class ShmShuffleManager (conf: SparkConf) extends ShuffleManager 
     }
   }
 
-  override val shortName: String = "shm"
+  // override val shortName: String = "shm"
 
   override def registerShuffle[K, V, C](
                                          shuffleId: Int,

--- a/firesteel/src/test/cpp/shuffle/CMakeLists.txt
+++ b/firesteel/src/test/cpp/shuffle/CMakeLists.txt
@@ -21,7 +21,7 @@ endfunction()
 
 function (add_common_test targetname)
   add_shuffle_test(${targetname})
-  target_link_libraries(${targetname} shm_management ${ALPS_LIBRARY} ${TBB_LIBRARY} boost_system boost_filesystem glog rt)
+  target_link_libraries(${targetname} shm_management ${ALPS_LIBRARY} ${TBB_LIBRARY} boost_system boost_filesystem glog rt pthread)
 endfunction()
 
 add_common_test(bytebufferpool_unitest)


### PR DESCRIPTION
Fix 4 syntax errors of sparkle.
1. `-SNAPSHOT` description in pom.xml (spark2.0 is no longer in development)
2. Add `#include <immintrin.h>` in [OffHeapStoreManager.cc](https://github.com/HewlettPackard/sparkle/blob/master/firesteel/src/main/cpp/offheapstore/OffHeapStoreManager.cc) for using `_mm_prefetch` and macros
3. Add `pthread` to target_link_libraries in CMakeLists.txt
4. Comment out `override val shortName` because shortName is not exist.

