### PR TITLE
remove tcmalloc from CMakeList because it cause pointer error on NUMA…

### DIFF
--- a/firesteel/src/main/cpp/combinedoffheapstore/CMakeLists.txt
+++ b/firesteel/src/main/cpp/combinedoffheapstore/CMakeLists.txt
@@ -21,4 +21,4 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_library(jnishmoffheapstore SHARED $<TARGET_OBJECTS:offheapstore> $<TARGET_OBJECTS:jnioffheapstore>)
 
 ## later, to find automatically the following shared libraries.
-target_link_libraries(jnishmoffheapstore ${ALPS_LIBRARY} shm_management tcmalloc ${TBB_LIBRARY} numa glog rt)
+target_link_libraries(jnishmoffheapstore ${ALPS_LIBRARY} shm_management ${TBB_LIBRARY} numa glog rt)

--- a/firesteel/src/main/cpp/combinedshuffle/CMakeLists.txt
+++ b/firesteel/src/main/cpp/combinedshuffle/CMakeLists.txt
@@ -21,4 +21,4 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_library(jnishmshuffle SHARED $<TARGET_OBJECTS:shuffle> $<TARGET_OBJECTS:jnishuffle>)
 
 ## later, to find automatically the following shared libraries.
-target_link_libraries(jnishmshuffle ${ALPS_LIBRARY} shm_management tcmalloc ${TBB_LIBRARY} numa glog rt)
+target_link_libraries(jnishmshuffle ${ALPS_LIBRARY} shm_management ${TBB_LIBRARY} numa glog rt)

--- a/firesteel/src/main/cpp/shmmanagement/CMakeLists.txt
+++ b/firesteel/src/main/cpp/shmmanagement/CMakeLists.txt
@@ -35,4 +35,4 @@ add_library(shm_management SHARED ${TMP_ALL_SHMMANAGEMENT_SRC})
 install (TARGETS shm_management DESTINATION lib)
 
 ## later, to find automatically the following shared libraries.
-target_link_libraries(shm_management ${ALPS_LIBRARY} tcmalloc glog)
+target_link_libraries(shm_management ${ALPS_LIBRARY} glog)


### PR DESCRIPTION
As stated in #5 , in current implementation, Sparkle fails with `attempt to free invalid pointer` error on NUMA environment.

This error seems to be caused by using tcmalloc in JNI, so I remove `tcmalloc` from target_link_libraries in CMakeLists. 

The reference why we suspected tcmalloc : [TCMalloc : Thread-Caching Malloc](http://goog-perftools.sourceforge.net/doc/tcmalloc.html)