### PR TITLE
modify application name displayed by HistoryServer

### DIFF
--- a/tests/multinodes/GroupBy/src/main/scala/org/apache/spark/examples/SparkGroupByPerformanceTestWithLong.scala
+++ b/tests/multinodes/GroupBy/src/main/scala/org/apache/spark/examples/SparkGroupByPerformanceTestWithLong.scala
@@ -38,7 +38,7 @@ object SparkGroupByPerformanceTestWithLong {
   }
 
   def main(args: Array[String]) {
-    val conf = new SparkConf().setAppName("simple multi-processed groupby")
+    val conf = new SparkConf().setAppName("simple multi-processed GroupBy")
     val sc = new SparkContext(conf)
 
     //to supress a null-pointer from running the test case.

--- a/tests/multinodes/PartitionBy/src/main/scala/org/apache/spark/examples/SparkPartitionByPerformanceTest.scala
+++ b/tests/multinodes/PartitionBy/src/main/scala/org/apache/spark/examples/SparkPartitionByPerformanceTest.scala
@@ -33,7 +33,7 @@ object SparkPartitionByPerformanceTest {
   }
 
   def main(args: Array[String]) {
-    val conf = new SparkConf().setAppName("simple multi-processed groupby")
+    val conf = new SparkConf().setAppName("simple multi-processed PartitionBy")
     val sc = new SparkContext(conf)
 
     //to supress a null-pointer from running the test case.

--- a/tests/multinodes/PartitionBy/src/main/scala/org/apache/spark/examples/SparkPartitionByPerformanceTestWithLong.scala
+++ b/tests/multinodes/PartitionBy/src/main/scala/org/apache/spark/examples/SparkPartitionByPerformanceTestWithLong.scala
@@ -33,7 +33,7 @@ object SparkPartitionByPerformanceTestWithLong {
   }
 
   def main(args: Array[String]) {
-    val conf = new SparkConf().setAppName("simple multi-processed groupby")
+    val conf = new SparkConf().setAppName("simple multi-processed PartitionBy")
     val sc = new SparkContext(conf)
 
     //to supress a null-pointer from running the test case.

--- a/tests/multinodes/ReduceBy/src/main/scala/org/apache/spark/examples/SparkReduceByPerformanceTestWithLong.scala
+++ b/tests/multinodes/ReduceBy/src/main/scala/org/apache/spark/examples/SparkReduceByPerformanceTestWithLong.scala
@@ -35,7 +35,7 @@ object SparkReduceByPerformanceTestWithLong {
   }
 
   def main(args: Array[String]) {
-    val conf = new SparkConf().setAppName("simple multi-processed groupby")
+    val conf = new SparkConf().setAppName("simple multi-processed ReduceBy")
     val sc = new SparkContext(conf)
 
     //to supress a null-pointer from running the test case.

--- a/tests/multinodes/SortBy/src/main/scala/org/apache/spark/examples/SparkSortByPerformanceTestWithLong.scala
+++ b/tests/multinodes/SortBy/src/main/scala/org/apache/spark/examples/SparkSortByPerformanceTestWithLong.scala
@@ -33,7 +33,7 @@ object SparkSortByPerformanceTestWithLong {
   }
 
   def main(args: Array[String]) {
-    val conf = new SparkConf().setAppName("simple multi-processed groupby")
+    val conf = new SparkConf().setAppName("simple multi-processed SortBy")
     val sc = new SparkContext(conf)
 
     //to supress a null-pointer from running the test case.


### PR DESCRIPTION
Fix setAppName because HistoryServer displays application name of GroupBy, ReduceBy, PartitionBy and SortBy as `simple multi-processed groupby".