### PR TITLE
Start Multiple Worker from start-spark.sh

### DIFF
--- a/deploy/virtualnode/templates/scripts/start-spark.sh
+++ b/deploy/virtualnode/templates/scripts/start-spark.sh
@@ -4,11 +4,15 @@ echo "start master...."
 
 sleep 10s 
 
+export SPARK_WORKER_WEBUI_PORT=8081
+export SPARK_WORKER_INSTANCES=1
+
 {% for i in range(0, num_workers) %}
 echo "start worker{{i}}...."
 export SPARK_IDENT_STRING=worker{{i}}
 ./multicore/worker{{i}}/sbin/start-slave.sh spark://{{ansible_hostname}}:7077
 
+((SPARK_WORKER_WEBUI_PORT++))
+((SPARK_WORKER_INSTANCES++))
+
 {% endfor %}
-
-


### PR DESCRIPTION
Fix multiple worker start from start-spark.sh script. Test result attached.

[start-spark-test.log](https://github.com/HewlettPackard/sparkle/files/3455284/start-spark-test.log)
